### PR TITLE
Removed Mann library directions

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,7 +122,7 @@ Preliminary schedule:
   Get directions with
   <a href="http://www.openstreetmap.org/?mlat={{ page.latlng | replace:',','&mlon=' }}&zoom=16">OpenStreetMap</a>
   or
-  <a href="http://maps.google.com/maps?q={{ page.latlng }}">Google Maps</a>.  Within Mann Library, B30A Classroom is in the basement as you exit the elevators.  See <a href="http://smartmap.mannlib.cornell.edu/location/b30a" target="_blank"> the floor plan </a>. 
+  <a href="http://maps.google.com/maps?q={{ page.latlng }}">Google Maps</a>. 
 </p>
 {% endif %}
 


### PR DESCRIPTION
The template had some info about a different workshop that I forgot to delete
